### PR TITLE
FIX: javadoc: error

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -121,6 +121,8 @@ public class ApiClient {
 
     /**
      * Format the given Date object into string.
+     * @param date Date
+     * @return Date in string format
      */
     public String formatDate(Date date) {
         return dateFormat.format(date);

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -147,6 +147,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.4</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Fix javadoc: error - The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.

